### PR TITLE
Fix bug in get_pr_sha() (#11)

### DIFF
--- a/R/git-pull-request.R
+++ b/R/git-pull-request.R
@@ -37,7 +37,7 @@ get_pr_sha <- function(branch = NULL) {
   sha_vec <- git("rev-list", "--right-only",
                  paste0("remotes/origin/", default, "..", branch),
                  echo_cmd = FALSE)
-  if ( sha_vec$status != 0L || isTRUE(sha_vec == "") ) {
+  if ( sha_vec$status != 0L || isTRUE(sha_vec$stdout == "") ) {
     NULL
   } else {
     sha_vec$stdout


### PR DESCRIPTION
- index the `stdout` properly in the `ifelse` so that the function returns `NULL` rather than `""` if there is no SHA to find
- fixes #10


## Overview of Pull Request

Fixes #10

---

### Change type
Please check the relevant box(es):

- [x] Bug fix (non-breaking change which fixes an issue)

