### PR TITLE
Add `gitr.echo_cmd` global option feature

### DIFF
--- a/R/git-tag.R
+++ b/R/git-tag.R
@@ -10,8 +10,7 @@ NULL
 #' @return [git_recent_tag()]: Character. The most recent tag.
 #' @export
 git_recent_tag <- function() {
-  tag <- utils::tail(git("tag", "-n")$stdout, 1L)
-  gsub("(^v[0-9]+\\.[0-9]+\\.[0-9]+).*", "\\1", tag)
+  utils::head(git("tag", "--sort=-taggerdate")$stdout, 1L)
 }
 
 #' @describeIn tag

--- a/R/git-tag.R
+++ b/R/git-tag.R
@@ -10,7 +10,7 @@ NULL
 #' @return [git_recent_tag()]: Character. The most recent tag.
 #' @export
 git_recent_tag <- function() {
-  utils::head(git("tag", "--sort=-taggerdate")$stdout, 1L)
+  utils::head(git("tag", "--sort=-taggerdate", echo_cmd = FALSE)$stdout, 1L)
 }
 
 #' @describeIn tag

--- a/R/git.R
+++ b/R/git.R
@@ -28,13 +28,14 @@ NULL
 #' @describeIn git
 #'   executes a `git` command line call from within R.
 #' @param echo_cmd Logical. Whether to print the command to run to the console.
+#'   Can be over-ridden globally via `option(gitr.echo_cmd = FALSE)`.
 #' @param ... Additional arguments passed to the system
 #'   command-line `git <command> [<args>]` call.
 #' @return [git()]: The system call ... invisibly.
 #' @export
 git <- function(..., echo_cmd = TRUE) {
-  if ( echo_cmd ) {
-    cat("Running git", c(...), "\n")
+  if ( getOption("gitr.echo_cmd", echo_cmd) ) {
+    cat("Running", slug_color(c("git", c(...)), "\033[034m"), "\n")
   }
   res  <- list(status = 0L, stdout = "", stderr = "")
   call <- suppressWarnings(

--- a/man/git.Rd
+++ b/man/git.Rd
@@ -19,7 +19,8 @@ git_checkout(branch = NULL)
 \item{...}{Additional arguments passed to the system
 command-line \verb{git <command> [<args>]} call.}
 
-\item{echo_cmd}{Logical. Whether to print the command to run to the console.}
+\item{echo_cmd}{Logical. Whether to print the command to run to the console.
+Can be over-ridden globally via \code{option(gitr.echo_cmd = FALSE)}.}
 
 \item{branch}{Character. The name of a branch, typically a
 feature branch.}

--- a/tests/testthat/_snaps/git.md
+++ b/tests/testthat/_snaps/git.md
@@ -1,0 +1,19 @@
+# silencing the git echo is possible via the `gitr.echo_cmd` global option
+
+    Code
+      git("--version")
+    Output
+      Running git --version 
+
+---
+
+    Code
+      git("--version")
+
+---
+
+    Code
+      git("--version", echo_cmd = FALSE)
+    Output
+      Running git --version 
+

--- a/tests/testthat/test-git.R
+++ b/tests/testthat/test-git.R
@@ -1,8 +1,26 @@
 
-test_that("the basic functionality of git() works as expected", {
+test_that("the basic functionality of `git()` works as expected", {
   skip_if(isTRUE(Sys.which("git") == ""))
   skip_if_not(is_git())
   expect_invisible(out <- git("status", echo_cmd = FALSE))
   expect_equal(out$status, 0L)
   expect_equal(out$stderr, "")
+})
+
+test_that("silencing the git echo is possible via the `gitr.echo_cmd` global option", {
+  # use `git("--version")` for testing b/c doesn't require a git repository
+  # default; TRUE
+  expect_snapshot(git("--version"))
+
+  # over-ride default; FALSE
+  withr::with_options(
+    list(gitr.echo_cmd = FALSE),
+    expect_snapshot(git("--version"))
+  )
+
+  # over-ride passed param; TRUE
+  withr::with_options(
+    list(gitr.echo_cmd = TRUE),
+    expect_snapshot(git("--version", echo_cmd = FALSE))
+  )
 })


### PR DESCRIPTION
## Overview of Pull Request

- the `echo_cmd` param is now additionally controlled by a global option, `gitr.echo_cmd`
- this option defaults to `TRUE`
- the new global option is takes precedence over passed the `echo_cmd` param of `git()`
- added color (blue) to the echoed command when this behavior is desired
- updated the docs to reflect this change and added new unit tests/snapshots
- closes #14
- fixes #16

---

### Change type
Please check the relevant box(es):

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature causing an API change)
- [x] Documentation update
- [ ] Package maintenance (structural, non-code, non-breaking changes)
- [ ] README change
- [ ] LICENSE changes
